### PR TITLE
fix: Add missing dependence statement

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
+    "babel-polyfill": "^6.23.0",
     "crypto-js": "^3.1.8",
     "js-yaml": "3.7.0",
     "lodash": "^4.17.0",


### PR DESCRIPTION
Package `babel-polyfill` was required in `index.js` line 18, but there is no dependence statement in `package.json`.